### PR TITLE
Update StubbornNetwork and adapt Examples

### DIFF
--- a/Demo/ContentView.swift
+++ b/Demo/ContentView.swift
@@ -27,10 +27,9 @@ struct ContentView: View {
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
 
-        let urlSession = StubbornNetwork.makePersistentSession(withName: "ContentView_Previews", path: "\(ProcessInfo().environment["PROJECT_DIR"] ?? "")/stubs", { (session) in
-            /// 2. `.playback` is the default
-            session.recordMode = .playback
-        })
+        let urlSession = StubbornNetwork.makePersistentSession(withName: "ContentView_Previews", path: "\(ProcessInfo().environment["PROJECT_DIR"] ?? "")/stubs")
+        /// 2. `.playback` is the default
+        urlSession.recordMode = .playback
 
         let networkClient = NetworkClient(urlSession: urlSession)
 

--- a/Demo/SceneDelegate.swift
+++ b/Demo/SceneDelegate.swift
@@ -14,7 +14,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
 
-
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
 
         let urlSession: URLSession
@@ -23,9 +22,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         if processInfo.testing == false {
             urlSession = URLSession(configuration: .ephemeral)
         } else {
-            urlSession = StubbornNetwork.makePersistentSession({ (stubbedURLSession) in
-                stubbedURLSession.recordMode = .playback
-            })
+            let session = StubbornNetwork.makePersistentSession()
+            session.recordMode = .playback
+            urlSession = session
         }
 
         let networkClient = NetworkClient(urlSession: urlSession)

--- a/DemoTests/DemoTests.swift
+++ b/DemoTests/DemoTests.swift
@@ -19,10 +19,10 @@ class DemoTests: XCTestCase {
         let exp = expectation(description: "Wait for publisher")
 
         /// given
-        let session = StubbornNetwork.makeEphemeralSession({ (stubbedSession) in // we make an ephemeral URLSession
-            stubbedSession.stub(NetworkClient.request, data: self.stubData, response: HTTPURLResponse(), error: nil) // and stub individual requests within this closure
-        })
-        let networkClient = NetworkClient(urlSession: session) // pass the session, fail it for the actual request.
+        let session = StubbornNetwork.makeEphemeralSession()
+        session.stub(NetworkClient.request, data: self.stubData, response: HTTPURLResponse(), error: nil) // and stub individual requests
+
+        let networkClient = NetworkClient(urlSession: session)
 
         /// when
         networkClient.post()

--- a/DemoUITests/DemoUITests.swift
+++ b/DemoUITests/DemoUITests.swift
@@ -30,13 +30,13 @@ class DemoUITests: XCTestCase {
 
     func testBytesText() {
         /// In the test itself everything happens like with an untampered URLSession
-        let bytesText = app.staticTexts["417 bytes"]
+        let bytesText = app.staticTexts["415 bytes"]
         wait(forElement:bytesText, timeout:2)
     }
 
     func testMoreBytesText() {
         /// Multiple tests will create multiple json files at the given path.
-        let bytesText = app.staticTexts["417 bytes"]
+        let bytesText = app.staticTexts["415 bytes"]
         wait(forElement:bytesText, timeout:2)
     }
 

--- a/DemoWorkspace.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DemoWorkspace.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/q231950/the-stubborn-network.git",
         "state": {
           "branch": "master",
-          "revision": "eb4724ce81582ef84280fdab13ecd29049a03ee4",
+          "revision": "7b827460bfbb8ebad8b476538a905cb6d30f1c5f",
           "version": null
         }
       }


### PR DESCRIPTION
Updates the examples to the newest version of **The Stubborn Network** and makes it compile since the API has changed quite a bit.